### PR TITLE
[Q4] Tennis Player API: More Supporting Endpoints

### DIFF
--- a/04-tennis-player/docs/docs.go
+++ b/04-tennis-player/docs/docs.go
@@ -181,6 +181,70 @@ var doc = `{
                 }
             }
         },
+        "/players/": {
+            "get": {
+                "description": "Resolves a Page of Players based on page and page size parameters.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "players"
+                ],
+                "summary": "Resolve a Page of Players.",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "The page number. Defaults to 1.",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of records on a page. Defaults to 10.",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.Page"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/players/addBall": {
             "post": {
                 "description": "Add balls to containers belonging to a particular user.",
@@ -244,6 +308,65 @@ var doc = `{
                     }
                 }
             }
+        },
+        "/players/{id}": {
+            "get": {
+                "description": "Resolves a Player by its ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "players"
+                ],
+                "summary": "Resolve a Player.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The Player's identifier.",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.Player"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -275,6 +398,26 @@ var doc = `{
                 },
                 "playerId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.Page": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "object"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalCount": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
                 }
             }
         },

--- a/04-tennis-player/docs/docs.go
+++ b/04-tennis-player/docs/docs.go
@@ -91,6 +91,129 @@ var doc = `{
                 }
             }
         },
+        "/containers/": {
+            "get": {
+                "description": "Resolves a Page of Containers based on page and page size parameters.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "containers"
+                ],
+                "summary": "Resolve a Page of Containers.",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "The page number. Defaults to 1.",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of records on a page. Defaults to 10.",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.Page"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/{id}": {
+            "get": {
+                "description": "Resolves a Container by its ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "containers"
+                ],
+                "summary": "Resolve a Container.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The Container's identifier.",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.Container"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "Performs a check on the server's health status.\nReturns HTTP 200/OK if healthy,\nreturns HTTP 503/Service Unavailable otherwise.",

--- a/04-tennis-player/docs/swagger.json
+++ b/04-tennis-player/docs/swagger.json
@@ -164,6 +164,70 @@
                 }
             }
         },
+        "/players/": {
+            "get": {
+                "description": "Resolves a Page of Players based on page and page size parameters.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "players"
+                ],
+                "summary": "Resolve a Page of Players.",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "The page number. Defaults to 1.",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of records on a page. Defaults to 10.",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.Page"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/players/addBall": {
             "post": {
                 "description": "Add balls to containers belonging to a particular user.",
@@ -227,6 +291,65 @@
                     }
                 }
             }
+        },
+        "/players/{id}": {
+            "get": {
+                "description": "Resolves a Player by its ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "players"
+                ],
+                "summary": "Resolve a Player.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The Player's identifier.",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.Player"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -258,6 +381,26 @@
                 },
                 "playerId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.Page": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "object"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalCount": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
                 }
             }
         },

--- a/04-tennis-player/docs/swagger.json
+++ b/04-tennis-player/docs/swagger.json
@@ -74,6 +74,129 @@
                 }
             }
         },
+        "/containers/": {
+            "get": {
+                "description": "Resolves a Page of Containers based on page and page size parameters.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "containers"
+                ],
+                "summary": "Resolve a Page of Containers.",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "The page number. Defaults to 1.",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of records on a page. Defaults to 10.",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.Page"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/{id}": {
+            "get": {
+                "description": "Resolves a Container by its ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "containers"
+                ],
+                "summary": "Resolve a Container.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The Container's identifier.",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.Container"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "Performs a check on the server's health status.\nReturns HTTP 200/OK if healthy,\nreturns HTTP 503/Service Unavailable otherwise.",

--- a/04-tennis-player/docs/swagger.yaml
+++ b/04-tennis-player/docs/swagger.yaml
@@ -19,6 +19,19 @@ definitions:
       playerId:
         type: string
     type: object
+  model.Page:
+    properties:
+      items:
+        type: object
+      page:
+        type: integer
+      pageSize:
+        type: integer
+      totalCount:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
   model.Player:
     properties:
       containers:
@@ -157,6 +170,81 @@ paths:
           schema:
             $ref: '#/definitions/response.BaseResponse'
       summary: Create a Player.
+      tags:
+      - players
+  /players/:
+    get:
+      description: Resolves a Page of Players based on page and page size parameters.
+      parameters:
+      - description: The page number. Defaults to 1.
+        in: query
+        name: page
+        type: integer
+      - description: The number of records on a page. Defaults to 10.
+        in: query
+        name: pageSize
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.BaseResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/model.Page'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+      summary: Resolve a Page of Players.
+      tags:
+      - players
+  /players/{id}:
+    get:
+      description: Resolves a Player by its ID.
+      parameters:
+      - description: The Player's identifier.
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.BaseResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/model.Player'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+      summary: Resolve a Player.
       tags:
       - players
   /players/addBall:

--- a/04-tennis-player/docs/swagger.yaml
+++ b/04-tennis-player/docs/swagger.yaml
@@ -113,6 +113,81 @@ paths:
       summary: Create a Container.
       tags:
       - containers
+  /containers/:
+    get:
+      description: Resolves a Page of Containers based on page and page size parameters.
+      parameters:
+      - description: The page number. Defaults to 1.
+        in: query
+        name: page
+        type: integer
+      - description: The number of records on a page. Defaults to 10.
+        in: query
+        name: pageSize
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.BaseResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/model.Page'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+      summary: Resolve a Page of Containers.
+      tags:
+      - containers
+  /containers/{id}:
+    get:
+      description: Resolves a Container by its ID.
+      parameters:
+      - description: The Container's identifier.
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.BaseResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/model.Container'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+      summary: Resolve a Container.
+      tags:
+      - containers
   /health:
     get:
       description: |-

--- a/04-tennis-player/handler/base.go
+++ b/04-tennis-player/handler/base.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/gorilla/mux"
+	"github.com/kerti/evm/04-tennis-player/handler/response"
+	"github.com/kerti/evm/04-tennis-player/util/failure"
+)
+
+func getIDFromRequest(w http.ResponseWriter, r *http.Request) (id uuid.UUID, err error) {
+	vars := mux.Vars(r)
+
+	id, err = uuid.FromString(vars["id"])
+	if err != nil {
+		response.RespondWithError(w, failure.BadRequest(err))
+	}
+
+	return
+}

--- a/04-tennis-player/handler/container.go
+++ b/04-tennis-player/handler/container.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/kerti/evm/04-tennis-player/handler/response"
 	"github.com/kerti/evm/04-tennis-player/model"
@@ -15,6 +16,8 @@ import (
 type Container interface {
 	Startup()
 	Shutdown()
+	HandleResolveByID(w http.ResponseWriter, r *http.Request)
+	HandleResolvePage(w http.ResponseWriter, r *http.Request)
 	HandleCreate(w http.ResponseWriter, r *http.Request)
 }
 
@@ -31,6 +34,95 @@ func (h *ContainerImpl) Startup() {
 // Shutdown cleans up everything and shuts down
 func (h *ContainerImpl) Shutdown() {
 	logger.Trace("Container Handler shutting down...")
+}
+
+// HandleResolveByID handles the request
+// @Summary Resolve a Container.
+// @Description Resolves a Container by its ID.
+// @Tags containers
+// @Produce json
+// @Param id path string true "The Container's identifier."
+// @Success 200 {object} response.BaseResponse{data=model.Container}
+// @Failure 400 {object} response.BaseResponse
+// @Failure 404 {object} response.BaseResponse
+// @Failure 500 {object} response.BaseResponse
+// @Router /containers/{id} [get]
+func (h *ContainerImpl) HandleResolveByID(w http.ResponseWriter, r *http.Request) {
+	id, err := getIDFromRequest(w, r)
+	if err != nil {
+		return
+	}
+
+	container, err := h.ContainerService.ResolveByID(id)
+	if err != nil {
+		response.RespondWithError(w, err)
+		return
+	}
+
+	response.RespondWithJSON(w, http.StatusOK, container)
+}
+
+// HandleResolvePage handles the request
+// @Summary Resolve a Page of Containers.
+// @Description Resolves a Page of Containers based on page and page size parameters.
+// @Tags containers
+// @Produce json
+// @Param page query int false "The page number. Defaults to 1."
+// @Param pageSize query int false "The number of records on a page. Defaults to 10."
+// @Success 200 {object} response.BaseResponse{data=model.Page}
+// @Failure 400 {object} response.BaseResponse
+// @Failure 404 {object} response.BaseResponse
+// @Failure 500 {object} response.BaseResponse
+// @Router /containers/ [get]
+func (h *ContainerImpl) HandleResolvePage(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseForm()
+	if err != nil {
+		response.RespondWithError(w, err)
+		return
+	}
+
+	pageNumStr, withPageNum := r.URL.Query()["page"]
+	pageSizeStr, withPageSize := r.URL.Query()["pageSize"]
+
+	pageNum := 1
+	if withPageNum && len(pageNumStr[0]) > 0 {
+		pageNum, err = strconv.Atoi(pageNumStr[0])
+		if err != nil {
+			response.RespondWithError(w, failure.BadRequest(err))
+			return
+		}
+	}
+
+	if pageNum <= 0 {
+		response.RespondWithError(
+			w,
+			failure.BadRequestFromString("page must be positive integer"))
+		return
+	}
+
+	pageSize := 10
+	if withPageSize && len(pageSizeStr[0]) > 0 {
+		pageSize, err = strconv.Atoi(pageSizeStr[0])
+		if err != nil {
+			response.RespondWithError(w, failure.BadRequest(err))
+			return
+		}
+	}
+
+	if pageSize <= 0 {
+		response.RespondWithError(
+			w,
+			failure.BadRequestFromString("page size must be positive integer"))
+		return
+	}
+
+	page, err := h.ContainerService.ResolvePage(pageNum, pageSize)
+	if err != nil {
+		response.RespondWithError(w, err)
+		return
+	}
+
+	response.RespondWithJSON(w, http.StatusOK, page)
 }
 
 // HandleCreate handles the request

--- a/04-tennis-player/handler/player.go
+++ b/04-tennis-player/handler/player.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/kerti/evm/04-tennis-player/handler/response"
 
@@ -16,6 +17,8 @@ import (
 type Player interface {
 	Startup()
 	Shutdown()
+	HandleResolveByID(w http.ResponseWriter, r *http.Request)
+	HandleResolvePage(w http.ResponseWriter, r *http.Request)
 	HandleCreate(w http.ResponseWriter, r *http.Request)
 	HandleAddBall(w http.ResponseWriter, r *http.Request)
 }
@@ -33,6 +36,95 @@ func (h *PlayerImpl) Startup() {
 // Shutdown cleans up everything and shuts down
 func (h *PlayerImpl) Shutdown() {
 	logger.Trace("Player Handler shutting down...")
+}
+
+// HandleResolveByID handles the request
+// @Summary Resolve a Player.
+// @Description Resolves a Player by its ID.
+// @Tags players
+// @Produce json
+// @Param id path string true "The Player's identifier."
+// @Success 200 {object} response.BaseResponse{data=model.Player}
+// @Failure 400 {object} response.BaseResponse
+// @Failure 404 {object} response.BaseResponse
+// @Failure 500 {object} response.BaseResponse
+// @Router /players/{id} [get]
+func (h *PlayerImpl) HandleResolveByID(w http.ResponseWriter, r *http.Request) {
+	id, err := getIDFromRequest(w, r)
+	if err != nil {
+		return
+	}
+
+	player, err := h.PlayerService.ResolveByID(id)
+	if err != nil {
+		response.RespondWithError(w, err)
+		return
+	}
+
+	response.RespondWithJSON(w, http.StatusOK, player)
+}
+
+// HandleResolvePage handles the request
+// @Summary Resolve a Page of Players.
+// @Description Resolves a Page of Players based on page and page size parameters.
+// @Tags players
+// @Produce json
+// @Param page query int false "The page number. Defaults to 1."
+// @Param pageSize query int false "The number of records on a page. Defaults to 10."
+// @Success 200 {object} response.BaseResponse{data=model.Page}
+// @Failure 400 {object} response.BaseResponse
+// @Failure 404 {object} response.BaseResponse
+// @Failure 500 {object} response.BaseResponse
+// @Router /players/ [get]
+func (h *PlayerImpl) HandleResolvePage(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseForm()
+	if err != nil {
+		response.RespondWithError(w, err)
+		return
+	}
+
+	pageNumStr, withPageNum := r.URL.Query()["page"]
+	pageSizeStr, withPageSize := r.URL.Query()["pageSize"]
+
+	pageNum := 1
+	if withPageNum && len(pageNumStr[0]) > 0 {
+		pageNum, err = strconv.Atoi(pageNumStr[0])
+		if err != nil {
+			response.RespondWithError(w, failure.BadRequest(err))
+			return
+		}
+	}
+
+	if pageNum <= 0 {
+		response.RespondWithError(
+			w,
+			failure.BadRequestFromString("page must be positive integer"))
+		return
+	}
+
+	pageSize := 10
+	if withPageSize && len(pageSizeStr[0]) > 0 {
+		pageSize, err = strconv.Atoi(pageSizeStr[0])
+		if err != nil {
+			response.RespondWithError(w, failure.BadRequest(err))
+			return
+		}
+	}
+
+	if pageSize <= 0 {
+		response.RespondWithError(
+			w,
+			failure.BadRequestFromString("page size must be positive integer"))
+		return
+	}
+
+	page, err := h.PlayerService.ResolvePage(pageNum, pageSize)
+	if err != nil {
+		response.RespondWithError(w, err)
+		return
+	}
+
+	response.RespondWithJSON(w, http.StatusOK, page)
 }
 
 // HandleCreate handles the request

--- a/04-tennis-player/model/base.go
+++ b/04-tennis-player/model/base.go
@@ -1,0 +1,20 @@
+package model
+
+// Page represents a Page of entities
+type Page struct {
+	Items      interface{} `json:"items"`
+	Page       int         `json:"page"`
+	PageSize   int         `json:"pageSize"`
+	TotalPages int         `json:"totalPages"`
+	TotalCount int         `json:"totalCount"`
+}
+
+// CalculateTotalPages calculates the total number of pages based on item count and page size
+func (p *Page) CalculateTotalPages() {
+	pages := p.TotalCount / p.PageSize
+	remainder := p.TotalCount - (p.PageSize * pages)
+	if remainder > 0 {
+		pages++
+	}
+	p.TotalPages = pages
+}

--- a/04-tennis-player/server/routes.go
+++ b/04-tennis-player/server/routes.go
@@ -30,6 +30,8 @@ func (s *Server) InitRoutes() {
 
 	// Players
 	s.router.HandleFunc("/players", s.PlayerHandler.HandleCreate).Methods("POST")
+	s.router.HandleFunc("/players/{id}", s.PlayerHandler.HandleResolveByID).Methods("GET")
+	s.router.HandleFunc("/players/", s.PlayerHandler.HandleResolvePage).Methods("GET")
 	s.router.HandleFunc("/players/addBall", s.PlayerHandler.HandleAddBall).Methods("POST")
 
 	http.Handle("/", s.router)

--- a/04-tennis-player/server/routes.go
+++ b/04-tennis-player/server/routes.go
@@ -26,6 +26,8 @@ func (s *Server) InitRoutes() {
 	s.router.HandleFunc("/health", s.HealthHandler.HandleHealthCheck).Methods("GET")
 
 	// Containers
+	s.router.HandleFunc("/containers/{id}", s.ContainerHandler.HandleResolveByID).Methods("GET")
+	s.router.HandleFunc("/containers/", s.ContainerHandler.HandleResolvePage).Methods("GET")
 	s.router.HandleFunc("/containers", s.ContainerHandler.HandleCreate).Methods("POST")
 
 	// Players

--- a/04-tennis-player/service/container.go
+++ b/04-tennis-player/service/container.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/kerti/evm/04-tennis-player/database"
 	"github.com/kerti/evm/04-tennis-player/model"
 	"github.com/kerti/evm/04-tennis-player/repository"
@@ -12,6 +13,8 @@ import (
 type Container interface {
 	Startup()
 	Shutdown()
+	ResolveByID(id uuid.UUID) (*model.Container, error)
+	ResolvePage(pageNum int, pageSize int) (*model.Page, error)
 	Create(input model.ContainerInput) (*model.Container, error)
 }
 
@@ -30,6 +33,25 @@ func (s *ContainerImpl) Startup() {
 // Shutdown cleans up everything and shuts down
 func (s *ContainerImpl) Shutdown() {
 	logger.Trace("Container Service shutting down...")
+}
+
+// ResolveByID resolves a Container by its ID
+func (s *ContainerImpl) ResolveByID(id uuid.UUID) (*model.Container, error) {
+	containers, err := s.ContainerRepository.ResolveByIDs([]uuid.UUID{id})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(containers) == 0 {
+		return nil, failure.EntityNotFound("container")
+	}
+
+	return &containers[0], nil
+}
+
+// ResolvePage resolves a Page of Containers based on page and page size parameters
+func (s *ContainerImpl) ResolvePage(pageNum int, pageSize int) (*model.Page, error) {
+	return s.ContainerRepository.ResolvePage(pageNum, pageSize)
 }
 
 // Create creates a new Container

--- a/04-tennis-player/service/player.go
+++ b/04-tennis-player/service/player.go
@@ -15,6 +15,8 @@ import (
 type Player interface {
 	Startup()
 	Shutdown()
+	ResolveByID(uuid.UUID) (*model.Player, error)
+	ResolvePage(pageNum int, pageSize int) (*model.Page, error)
 	Create(input model.PlayerInput) (*model.Player, error)
 	AddBall(playerID uuid.UUID) (*model.Player, error)
 }
@@ -35,6 +37,16 @@ func (s *PlayerImpl) Startup() {
 // Shutdown cleans up everything and shuts down
 func (s *PlayerImpl) Shutdown() {
 	logger.Trace("Player Service shutting down...")
+}
+
+// ResolveByID resolves a Player by its ID
+func (s *PlayerImpl) ResolveByID(id uuid.UUID) (*model.Player, error) {
+	return s.PlayerRepository.ResolveByID(id)
+}
+
+// ResolvePage resolves a Page of Players based on page and page size parameters
+func (s *PlayerImpl) ResolvePage(pageNum int, pageSize int) (*model.Page, error) {
+	return s.PlayerRepository.ResolvePage(pageNum, pageSize)
 }
 
 // Create creates a new Player

--- a/04-tennis-player/service/player.go
+++ b/04-tennis-player/service/player.go
@@ -41,7 +41,18 @@ func (s *PlayerImpl) Shutdown() {
 
 // ResolveByID resolves a Player by its ID
 func (s *PlayerImpl) ResolveByID(id uuid.UUID) (*model.Player, error) {
-	return s.PlayerRepository.ResolveByID(id)
+	player, err := s.PlayerRepository.ResolveByID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	containers, err := s.ContainerRepository.ResolveByPlayerID(player.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	player.AttachContainers(containers)
+	return player, nil
 }
 
 // ResolvePage resolves a Page of Players based on page and page size parameters

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Assessment v1.1**. This API is not available publicly and is deliberately
 minimal to emphasize on implementing concurrency handling as indicated in the
 problem statement.
 
-To run locally:
+### Running Locally
 
 1. Clone this repository.
 2. Go to `02-kitara-store` folder.
@@ -32,7 +32,7 @@ To run locally:
 The source code includes functional tests that are run concurrently to showcase
 the concurrency handling of the API.
 
-To test the concurrency feature:
+### Testing Concurrency Handling
 
 1. Have the API running as explained above.
 2. Open up a new terminal, go to `tests/functional` folder, then run `go test`.
@@ -59,7 +59,7 @@ This is the solution to **Question 1 of Evermos Backend Engineer Assessment
 v1.2**. This API is available publicly and testing can be done using the
 included Swagger Docs UI.
 
-## Assumptions
+### Assumptions
 
 To produce a reasonable API and logic within it, I made the following
 assumptions based on the problem statement:
@@ -72,7 +72,7 @@ assumptions based on the problem statement:
 * Once a Container is full (verified), the Player is then ready to play and he
   cannot put any more balls into any of his Containers.
 
-## Testing the Functionality
+### Testing the Functionality
 
 To test the API's functionality, I have included Swagger Docs UI that is
 available [here](http://tennis.evm.radityakertiyasa.com:8080/docs/index.html).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ The steps to test are as follows:
   like.
 * Invoke the `addBall` endpoint and observe the result. A single ball will
   added randomly into any one of the available Containers attached to the
-  Player. Do this until one of the Containers is full
+  Player. Do this until one of the Containers is full.
 * Once one of the Containers is full, you cannot invoke `addBall` on a Player
   because he is now ready to play.


### PR DESCRIPTION
Add the following endpoints:

* `GET /containers/` for resolving Containers by page
* `GET /containers/{id}` for resolving a Container by ID
* `GET /players/` for resolving Players by page
* `GET /players/{id}` for resolving a Player by ID

Please refer to the live Swagger Docs UI for more information.

I also put in some touch-ups to README in this PR.